### PR TITLE
Specify Ruby installer version 1 instead of specific v1.172.0

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Ruby packages
-        uses: ruby/setup-ruby@v1.172.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
           bundler-cache: true

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-site:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Debug dump

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-site:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Debug dump


### PR DESCRIPTION
Because the specific version v1.172.0 isn´t able to use ´ubuntu-latest´ which uses ubuntu 24

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
